### PR TITLE
Bringing the code up to date with latest rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(warnings)]
 #![feature(raw)]
 #![feature(plugin)]
-#![feature(simd)]
+#![feature(repr_simd)]
 
 #[cfg(test)] extern crate test as stdtest;
 #[cfg(test)] extern crate approx;
@@ -27,12 +27,12 @@ pub mod traits;
 
 #[allow(missing_docs, non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
-#[simd]
+#[repr(simd)]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
 #[allow(missing_docs, non_camel_case_types)]
 #[derive(Clone, Copy, Debug)]
-#[simd]
+#[repr(simd)]
 pub struct f64x2(pub f64, pub f64);
 
 /// Sum the elements of a slice using SIMD ops

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(test, plugin(quickcheck_macros))]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(core)]
+#![feature(raw)]
 #![feature(plugin)]
 #![feature(simd)]
 


### PR DESCRIPTION
Two tiny fixes to the code. It still does not compile because of infinite recursion.

I'm not sure why we need these types instead of using the one in the official `simd` crate so I'm not going to put any more work into this before I understand that reason.
